### PR TITLE
:bug: fix: 修复不能构建，更新Dockerfile的go版本

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.6-alpine as builder
+FROM golang:1.18.6-alpine as builder
 LABEL maintainer = "Linhe Huo <linhe.huo@gmail.com>"
 
 WORKDIR /usr/src/taoskeeper


### PR DESCRIPTION
直接用仓库自带的Dockerfile不能构建，需要升级编译镜像